### PR TITLE
Add Python 3 compatibility 

### DIFF
--- a/mailparser/__init__.py
+++ b/mailparser/__init__.py
@@ -27,6 +27,9 @@ import ipaddress
 import logging
 import re
 import time
+import sys
+
+py_version = sys.version_info[0]
 
 try:
     import simplejson as json
@@ -63,28 +66,48 @@ class MailParser(object):
         try:
             for i in decode_header(header):
                 if i[1]:
-                    output += unicode(i[0], i[1], errors='ignore').strip()
+                    if py_version == 2:
+                        output += unicode(i[0], i[1], errors='ignore').strip()
+                    elif py_version == 3:
+                        output += str(i[0], i[1],).lstrip()
                 else:
-                    output += unicode(i[0], errors='ignore').strip()
+                    if py_version == 2:
+                        output += unicode(i[0], errors='ignore').strip()
+                    elif py_version == 3:
+                        output += str(i[0],).lstrip()
 
         # Header parsing failed, when header has charset Shift_JIS
         except HeaderParseError:
             log.error("Failed decoding header part: {}".format(header))
             output += header
 
-        if not isinstance(output, unicode):
-            raise NotUnicodeError("Header part is not unicode")
+        if py_version == 2:
+            if not isinstance(output, unicode):
+                raise NotUnicodeError("Header part is not unicode")
+        elif py_version == 3:
+            if not isinstance(output, str):
+                raise NotUnicodeError("Header part is not unicode")
 
         return output
 
     def _force_unicode(self, string, encoding):
         try:
-            u = unicode(string, encoding=encoding, errors='ignore')
+            if py_version == 2:
+                u = unicode(string, encoding=encoding, errors='ignore')
+            elif py_version == 3:
+                u = str(string, encoding=encoding, errors='ignore')
         except:
-            u = unicode(string, errors='ignore',)
+            if py_version == 2:
+                u = unicode(string, errors='ignore',)
+            elif py_version == 3:
+                u = str(string, errors='ignore',)
 
-        if not isinstance(u, unicode):
-            raise NotUnicodeError("Body part is not unicode")
+        if py_version == 2:
+            if not isinstance(u, unicode):
+                raise NotUnicodeError("Body part is not unicode")
+        elif py_version == 3:
+            if not isinstance(u, str):
+                raise NotUnicodeError("Body part is not unicode")
 
         return u
 
@@ -168,8 +191,10 @@ class MailParser(object):
                     filename = self._decode_header_part(f)
                     mail_content_type = self._decode_header_part(
                         p.get_content_type())
-                    transfer_encoding = \
-                        unicode(p.get('content-transfer-encoding', '')).lower()
+                    if py_version == 2:
+                        transfer_encoding = unicode(p.get('content-transfer-encoding', '')).lower()
+                    elif py_version == 3:
+                        transfer_encoding = str(p.get('content-transfer-encoding', '')).lower()
 
                     if transfer_encoding == "base64":
                         payload = p.get_payload(decode=False)

--- a/mailparser/__init__.py
+++ b/mailparser/__init__.py
@@ -50,7 +50,7 @@ class MailParser(object):
     def parse_from_file(self, fd):
         """Parsing mail from file. """
 
-        with open(fd) as mail:
+        with open(fd, encoding='utf-8', errors='replace') as mail:
             self._message = email.message_from_file(mail)
             self._parse()
 
@@ -270,12 +270,18 @@ class MailParser(object):
                 check = r.findall(i[0:i.find("by")])
                 if check:
                     try:
-                        ip = ipaddress.ip_address(unicode(check[-1]))
+                        if py_version == 2:
+                            ip = ipaddress.ip_address(unicode(check[-1]))
+                        elif py_version == 3:
+                            ip = ipaddress.ip_address(str(check[-1]))
                     except ValueError:
                         return
 
                     if not ip.is_private:
-                        return unicode(check[-1])
+                        if py_version == 2:
+                            return unicode(check[-1])
+                        elif py_version == 3:
+                            return str(check[-1])
 
     @property
     def body(self):

--- a/mailparser/__main__.py
+++ b/mailparser/__main__.py
@@ -154,6 +154,9 @@ def main():
     if args.to:
         print(parser.to_.encode('utf-8'))
 
+    if args.X_Original_To:
+        print(parser.X_Original_To__.encode('utf-8'))
+
     if args.from_:
         print(parser.from_.encode('utf-8'))
 

--- a/tests/test_mail_parser.py
+++ b/tests/test_mail_parser.py
@@ -102,33 +102,37 @@ class TestMailParser(unittest.TestCase):
         self.assertIsInstance(result, dict)
         self.assertNotIn("defects", result)
         self.assertNotIn("anomalies", result)
+        if py_version == 2:
+            check = unicode
+        elif py_version == 3:
+            check = str
 
         result = parser.get_server_ipaddress(trust)
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, check)
 
         result = parser.parsed_mail_json
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, check)
 
         result = parser.headers
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, check)
 
         result = parser.body
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, check)
 
         result = parser.date_mail
         self.assertIsInstance(result, datetime.datetime)
 
         result = parser.from_
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, check)
 
         result = parser.to_
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, check)
 
         result = parser.subject
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, check)
 
         result = parser.message_id
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, check)
 
         result = parser.attachments_list
         self.assertIsInstance(result, list)

--- a/tests/test_mail_parser.py
+++ b/tests/test_mail_parser.py
@@ -34,6 +34,7 @@ mail_malformed_2 = os.path.join(base_path, 'mails', 'mail_malformed_2')
 sys.path.append(root)
 import mailparser
 
+py_version = sys.version_info[0]
 
 class TestMailParser(unittest.TestCase):
 
@@ -150,7 +151,10 @@ class TestMailParser(unittest.TestCase):
         self.assertEqual(1, len(parser.defects_category))
         self.assertIn("defects", parser.parsed_mail_obj)
         self.assertIn("StartBoundaryNotFoundDefect", parser.defects_category)
-        self.assertIsInstance(parser.parsed_mail_json, unicode)
+        if py_version == 2:
+            self.assertIsInstance(parser.parsed_mail_json, unicode)
+        elif py_version == 3:
+            self.assertIsInstance(parser.parsed_mail_json, str)
 
         result = len(parser.attachments_list)
         self.assertEqual(1, result)
@@ -170,7 +174,10 @@ class TestMailParser(unittest.TestCase):
         self.assertEqual(1, len(parser.defects_category))
         self.assertIn("defects", parser.parsed_mail_obj)
         self.assertIn("StartBoundaryNotFoundDefect", parser.defects_category)
-        self.assertIsInstance(parser.parsed_mail_json, unicode)
+        if py_version == 2:
+            self.assertIsInstance(parser.parsed_mail_json, unicode)
+        elif py_version == 3:
+            self.assertIsInstance(parser.parsed_mail_json, str)
 
         result = len(parser.attachments_list)
         self.assertEqual(0, result)
@@ -187,14 +194,26 @@ class TestMailParser(unittest.TestCase):
             len(result["attachments"]),
             1
         )
-        self.assertIsInstance(
-            result["attachments"][0]["mail_content_type"],
-            unicode
-        )
-        self.assertIsInstance(
-            result["attachments"][0]["payload"],
-            unicode
-        )
+        if py_version == 2:
+            self.assertIsInstance(
+                result["attachments"][0]["mail_content_type"],
+                unicode
+            )
+        elif py_version == 3:
+            self.assertIsInstance(
+                result["attachments"][0]["mail_content_type"],
+                str 
+            )
+        if py_version == 2:
+            self.assertIsInstance(
+                result["attachments"][0]["payload"],
+                unicode
+            )
+        elif py_version == 3:
+            self.assertIsInstance(
+                result["attachments"][0]["payload"],
+                str 
+            )
         self.assertEqual(
             result["attachments"][0]["content_transfer_encoding"],
             "quoted-printable",


### PR DESCRIPTION
This follow the old PR, but solve, I believe, the problem with charset and unicode!
And I made some modifications in teste_mail_parser for Python 3.

  