### PR TITLE
accept file object.

### DIFF
--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -109,12 +109,13 @@ class MailParser(object):
         Returns:
             Instance of MailParser
         """
-
-        with ported_open(fp) as f:
-            message = email.message_from_file(f)
-
-        if is_outlook:
-            os.remove(fp)
+        if type(fp) == str:
+            with ported_open(fp) as f:
+                message = email.message_from_file(f)
+            if is_outlook:
+                os.remove(fp)
+        else:
+            message = email.message_from_file(fp)
 
         return cls(message)
 


### PR DESCRIPTION
mailparser.parse_from_file() should accept file object.

It should be the same as email.message_from_file().

Currently we can't handle mail from standard input.