### PR TITLE
Add Docker workflow support for building and testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:onbuild
+
+RUN python setup.py install
+
+ENTRYPOINT [ "mailparser" ]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ or use `pip`:
 $ pip install mail-parser
 ```
 
+### Building with Docker
+Complete working Docker workflow is possible allowing you to start hacking and building without any other requirements or dependencies. All the required libs and build tools are handled by Docker build process.
+Using the provided Dockerfile you can build a complete working image with all the required dependencies. If you're not familiar with Docker, better use Docker Compose to both build and run your source easy and effortlessly.
+
+From the ```docker-compose.yml``` directory, run:
+```
+$ docker-compose up --build
+```
+Skip the ```--build``` switch to launch the last built container image without rebuilding again.
+
+The provided ```docker-compose.yml``` file is configured to:
+
+* Mount your host's ```tests/mails/``` dir from your source tree inside the container at ```/data/``` (read-only).
+* A command line test example.
+
+See the ```docker-compose.yml``` to view and tweak the launch parameters.
+
 ## Usage in a project
 
 Import `mailparser` module:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+# Docker Compose build manifest.
+# Usage:
+# $ docker-compose up --build
+
+mailparser:
+  build: .
+  command: --json -f /mails/mail_test_1
+  volumes:
+    - ./tests/mails/:/mails/:ro


### PR DESCRIPTION
No building/compiling toolchain nor development libs installation needed on development host, just Docker and Docker Compose and you can start hacking! People familiar with Docker will figure out themselves, but quickstart docs are provided. I hope they're of enough help. Indeed, it enabled me to start hacking right away and it's the workflow I'm using.

The built image will be also useful later to create public Docker images as an automatic, hands-free distribution method. Useful to run the program without installing anything other than Docker or to create customized child images, always based on a direct built-from-latest-sources (see mine at https://hub.docker.com/r/pataquets/mail-parser-src/ as example).