### PR TITLE
Parse To: header into a list of recipients instead of a string.

### DIFF
--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -285,6 +285,7 @@ class MailParser(object):
     def _reset(self):
         """Reset the state of object. """
 
+        self._to = list()
         self._attachments = list()
         self._text_plain = list()
         self._defects = list()
@@ -305,7 +306,7 @@ class MailParser(object):
             "headers": self.headers,
             "message_id": self.message_id,
             "subject": self.subject,
-            "to": self.to_,
+            "to": email.utils.getaddresses([self.to_]),
             "receiveds": self.receiveds_obj,
             "has_defects": self.has_defects,
             "has_anomalies": self.has_anomalies}


### PR DESCRIPTION
To store multi-recipient messages I need a correctly structured JSON with the "To:" field to be returned as a list. Just by ```split()```'ting  by commas doesn't cuts it, since [RFC-2822 address specification](https://tools.ietf.org/html/rfc2822#section-3.4) is more complex.

Fortunately, Python's [```email.utils.getaddresses```](https://docs.python.org/3/library/email.util.html#email.utils.getaddresses) handles this. It even splits indvidual addresses into 'real name' and 'email address' parts.

Output using ```tests/mails/mail_test_1```:
```
[...]
mailparser_1  |     "subject": "письмо уведом-е",
mailparser_1  |     "to": [
mailparser_1  |         [
mailparser_1  |             "",
mailparser_1  |             "kinney@noth.com"
mailparser_1  |         ]
mailparser_1  |     ],
mailparser_1  |     "receiveds": [
[...]
```

Another (real) test message of mine containing the following 'To:':
```
To: echo@tu-berlin.de, "Test recipient, containing comma" <echo@tu-berlin.de>
```
gets parsed into:
```
mailparser_1  |     "to": [
mailparser_1  |         [
mailparser_1  |             "",
mailparser_1  |             "echo@tu-berlin.de"
mailparser_1  |         ],
mailparser_1  |         [
mailparser_1  |             "Test recipient, containing comma",
mailparser_1  |             "echo@tu-berlin.de"
mailparser_1  |         ]
mailparser_1  |     ],
mailparser_1  |     "receiveds": [
```

(mailparser_1 is Docker Compose's leading prefix, since I'm using it to hack, see #12)

Also, FYI, I'm about to do the same for the 'Headers:' field.