### PR TITLE
Add headers parsing into a list in addition to a string. Also, use it for JSON output

### DIFF
--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -303,7 +303,7 @@ class MailParser(object):
             "body": self.body,
             "date": self.date_mail,
             "from": self.from_,
-            "headers": self.headers,
+            "headers": self.headers_obj,
             "message_id": self.message_id,
             "subject": self.subject,
             "to": email.utils.getaddresses([self.to_]),
@@ -479,14 +479,24 @@ class MailParser(object):
 
     @property
     def body(self):
-        """Return the only the body. """
+        """Return only the body. """
         return "\n".join(self.text_plain_list)
 
     @property
+    def headers_obj(self):
+        """Return all headers as object
+
+        Return:
+            list of headers
+        """
+
+        return self.message.items()
+
+    @property
     def headers(self):
-        """Return the only the headers. """
+        """Return only the headers. """
         s = ""
-        for k, v in self.message.items():
+        for k, v in self.headers_obj:
             v_u = re.sub(" +", " ", decode_header_part(v))
             s += k + ": " + v_u + "\n"
         return s


### PR DESCRIPTION
After dealing with #13, I was working to do the same for the ```.headers``` property.
However, this time I've found that the ```\n```-delimited string is on purpose. So, to avoid breaking things with the library, I've resorted to do it as it's done for the 'receiveds' field, by creating a ```headers_obj()``` property separate from ```headers()```. Also, ```headers()``` now relies on the ```headers_obj()``` property, as 'receiveds' does.
When JSON output is requested, the object is used instead of the string property, since ```_make_mail()``` switched to use it.