### PR TITLE
Improve 'To' and 'Reply-To' headers handling

### DIFF
--- a/README
+++ b/README
@@ -23,8 +23,8 @@ Description
 
 mail-parser takes as input a raw mail and generates a parsed object.
 This object is a tokenized email with some indicator: 
-- body - headers - subject - from - to - attachments - message id - date 
-- charset mail - sender IP address - receiveds
+- body - headers - subject - from - to - delivered_to - attachments - message id
+- date - charset mail - sender IP address - receiveds
 
 We have also two types of indicator: - anomalies: mail without message id or date
 - `defects`_: mail with some not compliance RFC part
@@ -96,6 +96,7 @@ Then you can get all parts
     mail.headers
     mail.message_id
     mail.to_
+    mail.delivered_to_
     mail.from_
     mail.subject
     mail.text_plain_list: only text plain mail parts in a list
@@ -125,7 +126,7 @@ These are all swithes:
 
 ::
 
-    usage: mailparser [-h] (-f FILE | -s STRING | -k) [-j] [-b] [-a] [-r] [-t] [-m]
+    usage: mailparser [-h] (-f FILE | -s STRING | -k) [-j] [-b] [-a] [-r] [-t] [-dt] [-m]
                       [-u] [-c] [-d] [-n] [-i Trust mail server string] [-p] [-z] 
                       [-v]
 
@@ -143,6 +144,7 @@ These are all swithes:
       -a, --attachments     Print the attachments of mail (default: False)
       -r, --headers         Print the headers of mail (default: False)
       -t, --to              Print the to of mail (default: False)
+      -dt, --delivered-to   Print the delivered-to of mail (default: False)
       -m, --from            Print the from of mail (default: False)
       -u, --subject         Print the subject of mail (default: False)
       -c, --receiveds       Print all receiveds of mail (default: False)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ mail-parser takes as input a raw email and generates a parsed object. This objec
   - subject
   - from
   - to
+  - delivered_to
   - attachments
   - message id
   - date
@@ -118,6 +119,7 @@ mail.body
 mail.headers
 mail.message_id
 mail.to_
+mail.delivered_to_
 mail.from_
 mail.subject
 mail.text_plain_list: only text plain mail parts in a list
@@ -141,7 +143,7 @@ If you installed mailparser with `pip` or `setup.py` you can use it with command
 These are all swithes:
 
 ```
-usage: mailparser.py [-h] (-f FILE | -s STRING | -k) [-j] [-b] [-a] [-r] [-t] [-m]
+usage: mailparser.py [-h] (-f FILE | -s STRING | -k) [-j] [-b] [-a] [-r] [-t] [-dt] [-m]
                    [-u] [-c] [-d] [-n] [-i Trust mail server string] [-p] [-z] 
                    [-v]
 
@@ -158,6 +160,7 @@ optional arguments:
   -a, --attachments     Print the attachments of mail (default: False)
   -r, --headers         Print the headers of mail (default: False)
   -t, --to              Print the to of mail (default: False)
+  -dt, --delivered-to   Print the delivered-to of mail (default: False)
   -m, --from            Print the from of mail (default: False)
   -u, --subject         Print the subject of mail (default: False)
   -c, --receiveds       Print all receiveds of mail (default: False)

--- a/mailparser/__main__.py
+++ b/mailparser/__main__.py
@@ -103,6 +103,13 @@ def get_args():
         help="Print the to of mail")
 
     parser.add_argument(
+        "-dt",
+        "--delivered-to",
+        dest="delivered_to",
+        action="store_true",
+        help="Print the delivered-to of mail")
+
+    parser.add_argument(
         "-m",
         "--from",
         dest="from_",
@@ -232,6 +239,9 @@ def main():
 
     if args.to:
         safe_print(json.dumps(parser.to_))
+
+    if args.delivered_to:
+        safe_print(json.dumps(parser.delivered_to_))
 
     if args.from_:
         safe_print(parser.from_)

--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -285,7 +285,6 @@ class MailParser(object):
     def _reset(self):
         """Reset the state of object. """
 
-        self._to = list()
         self._attachments = list()
         self._text_plain = list()
         self._defects = list()

--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -20,6 +20,7 @@ limitations under the License.
 from __future__ import unicode_literals
 import datetime
 import email
+from email.header import decode_header
 import logging
 import os
 import re
@@ -306,6 +307,7 @@ class MailParser(object):
             "message_id": self.message_id,
             "subject": self.subject,
             "to": self.to_,
+            "delivered_to": self.delivered_to_,
             "receiveds": self.receiveds_obj,
             "has_defects": self.has_defects,
             "has_anomalies": self.has_anomalies}
@@ -516,6 +518,13 @@ class MailParser(object):
         to_ = decode_header_part(self.message.get(
             'to', self.message.get('delivered-to', '')))
         return email.utils.getaddresses([to_])
+
+    @property
+    def delivered_to_(self):
+        """Return the receiver of message. """
+        delivered_to_ = decode_header_part(
+            self.message.get('delivered-to', ''))
+        return email.utils.getaddresses([delivered_to_])
 
     @property
     def from_(self):

--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -515,7 +515,7 @@ class MailParser(object):
         """Return the receiver of message. """
         to_ = decode_header_part(self.message.get(
             'to', self.message.get('delivered-to', '')))
-        return email.utils.parseaddr([to_]),
+        return email.utils.getaddresses([to_])
 
     @property
     def from_(self):

--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -303,7 +303,7 @@ class MailParser(object):
             "body": self.body,
             "date": self.date_mail,
             "from": self.from_,
-            "headers": self.headers,
+            "headers": self.headers_obj,
             "message_id": self.message_id,
             "subject": self.subject,
             "to": email.utils.getaddresses([self.to_]),
@@ -479,14 +479,24 @@ class MailParser(object):
 
     @property
     def body(self):
-        """Return the only the body. """
+        """Return only the body. """
         return "\n".join(self.text_plain_list)
 
     @property
+    def headers_obj(self):
+        """Return all headers as object
+
+        Return:
+            list of headers
+        """
+
+        return self.message.items()
+
+    @property
     def headers(self):
-        """Return the only the headers. """
+        """Return only the headers. """
         s = ""
-        for k, v in self.message.items():
+        for k, v in self.headers_obj:
             v_u = re.sub(" +", " ", decode_header_part(v))
             s += k + ": " + v_u + "\n"
         return s

--- a/tests/mails/mail_test_2
+++ b/tests/mails/mail_test_2
@@ -1,4 +1,5 @@
 Return-Path: <meteo@regione.vda.it>
+To: echo@tu-berlin.de, "Porcile, M." <mporcile@server_mail.it>
 Delivered-To: mporcile@server_mail.it
 Received: (qmail 21858 invoked from network); 29 Nov 2015 08:46:02 -0000
 Received: from smtp2.regione.vda.it (217.76.210.112)


### PR DESCRIPTION
After feedback on #13 and testing 0086ec0c859f042f61f8f307912c1ff160ab2771:
* The resulting 'To:' field handling doesn't support multi-recipient field values ([getaddresses()](https://docs.python.org/2/library/email.util.html#email.utils.getaddresses) vs. [parseaddr()](https://docs.python.org/2/library/email.util.html#email.utils.parseaddr). Attempted to fix that.
* Added a specific, stand-alone 'reply-to' field. This might enable in a future to use the 'to' property to just only the 'To:' header, but not sure, though.
* Added an examplo 'To:' header to a test email to easily demo a multi-recipient header (a tricky one, containing the field value separator, which is comma).

Needed/broken:
* Tests. I've seen where and how they're done.
* The ```to()``` property is currently ignoring the 'reply-to' (ouch!). How do I proceed? Merge 'to'+'reply-to' for compatibility or separate fields and break?
* Add test running to Dockerfile? (I wil grab them from ```.travis.yml```).

I've paused work on #14 until I get more feedback and learn a bit more about the software, since they're related.
Disclaimer: Python is not my main language :)