### PR TITLE
stick to ASCII on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,11 +221,11 @@ Exceptions hierarchy of mail-parser:
 
     MailParserError: Base MailParser Exception
     |
-    ├── MailParserOutlookError: Raised with Outlook integration errors
+    \-- MailParserOutlookError: Raised with Outlook integration errors
     |
-    ├── MailParserEnvironmentError: Raised when the environment is not correct
+    \-- MailParserEnvironmentError: Raised when the environment is not correct
     |
-    ├── MailParserOSError: Raised when there is an OS error
+    \-- MailParserOSError: Raised when there is an OS error
 
 .. |PyPI version| image:: https://badge.fury.io/py/mail-parser.svg
    :target: https://badge.fury.io/py/mail-parser


### PR DESCRIPTION
... so that installation does not fail on systems with standard C locale

Fixes #30.

Pull request #32, provides an alternative fix.