### PR TITLE
decode README as UTF-8 on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,14 @@ limitations under the License.
 """
 
 import os
+import io
 import runpy
 from setuptools import setup
 
 
 current = os.path.realpath(os.path.dirname(__file__))
 
-with open(os.path.join(current, 'README.rst')) as f:
+with io.open(os.path.join(current, 'README.rst'), encoding="utf-8") as f:
     long_description = f.read()
 
 with open(os.path.join(current, 'requirements.txt')) as f:


### PR DESCRIPTION
... so that installation does not fail on systems with standard C locale

fixes #30 

I had to use `io.open` instead of `open` to make this portable across python2/3.

Pull request #31 provides an alternative fix.