### PR TITLE
Fix bug in header parsing

### DIFF
--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -492,6 +492,8 @@ class MailParser(object):
         elif name_header in ADDRESSES_HEADERS:
             h = decode_header_part(self.message.get(
                 name_header, six.text_type()))
+            h = h.replace('\r\n ', ' ')
+            h = h.replace('\r\n\t', '\t')
             return email.utils.getaddresses([h])
 
         # others headers


### PR DESCRIPTION
This PR fixes a bug where a CRLF ("folding" according to the RFC) in `ADDRESSES_HEADERS` would cause incorrect value extraction. For example, `getaddresses()` fails to parse this correctly, which will lead to an incorrect value in the respective mailparser field.

For example, this will fail:
```
foo = '"test \r\n" <foo@bar.com>'
print(email.utils.getaddresses([foo]))
[('', 'test ')]
```

According to RFC822:
```
Unfolding is accomplished by regarding CRLF immediately followed by a LWSP-char 
as equivalent to the LWSP-char.
```

LWSP-char as defined by the RFC:
```
LWSP-char   =  SPACE / HTAB                 ; semantics = SPACE
```

### References
See RFC on "folding": https://tools.ietf.org/html/rfc822#section-3.1.1
See "linesep": https://docs.python.org/3/library/email.header.html#email.header.Header.encode