### PR TITLE
Added support to enable/disable received header parsing errors

### DIFF
--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -599,8 +599,8 @@ class MailParser(object):
         Return only the headers as Python object
         """
         d = {}
-        for k, v in self.message.items():
-            d[k] = decode_header_part(v)
+        for i in self.message.keys():
+            d[i] = getattr(self, i)
         return d
 
     @property

--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -378,7 +378,9 @@ class MailParser(object):
                 filename = decode_header_part(p.get_filename())
 
                 is_attachment = False
-                if filename:
+                if content_disposition:
+                    is_attachment = True
+                elif filename:
                     is_attachment = True
                 else:
                     if content_id and content_subtype not in ('html', 'plain'):

--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -53,69 +53,74 @@ from .exceptions import MailParserEnvironmentError
 log = logging.getLogger(__name__)
 
 
-def parse_from_file_obj(fp):
+def parse_from_file_obj(fp, log_received_parse_errors=True):
     """
     Parsing email from a file-like object.
 
     Args:
         fp (file-like object): file-like object of raw email
+        log_received_parse_errors (bool): if True then only log error
 
     Returns:
         Instance of MailParser with raw email parsed
     """
-    return MailParser.from_file_obj(fp)
+    return MailParser.from_file_obj(fp, log_received_parse_errors=log_received_parse_errors)
 
 
-def parse_from_file(fp):
+def parse_from_file(fp, log_received_parse_errors=True):
     """
     Parsing email from file.
 
     Args:
         fp (string): file path of raw email
+        log_received_parse_errors (bool): if True then only log error
 
     Returns:
         Instance of MailParser with raw email parsed
     """
-    return MailParser.from_file(fp)
+    return MailParser.from_file(fp, log_received_parse_errors=log_received_parse_errors)
 
 
-def parse_from_file_msg(fp):
+def parse_from_file_msg(fp, log_received_parse_errors=True):
     """
     Parsing email from file Outlook msg.
 
     Args:
         fp (string): file path of raw Outlook email
+        log_received_parse_errors (bool): if True then only log error
 
     Returns:
         Instance of MailParser with raw email parsed
     """
-    return MailParser.from_file_msg(fp)
+    return MailParser.from_file_msg(fp, log_received_parse_errors=log_received_parse_errors)
 
 
-def parse_from_string(s):
+def parse_from_string(s, log_received_parse_errors=True):
     """
     Parsing email from string.
 
     Args:
         s (string): raw email
+        log_received_parse_errors (bool): if True then only log error
 
     Returns:
         Instance of MailParser with raw email parsed
     """
-    return MailParser.from_string(s)
+    return MailParser.from_string(s, log_received_parse_errors=log_received_parse_errors)
 
 
-def parse_from_bytes(bt):
+def parse_from_bytes(bt, log_received_parse_errors=True):
     """
     Parsing email from bytes. Only for Python 3
 
     Args:
         bt (bytes-like object): raw email as bytes-like object
+        log_received_parse_errors (bool): if True then only log error
 
     Returns:
         Instance of MailParser with raw email parsed
     """
-    return MailParser.from_bytes(bt)
+    return MailParser.from_bytes(bt, log_received_parse_errors=log_received_parse_errors)
 
 
 class MailParser(object):
@@ -128,11 +133,12 @@ class MailParser(object):
     https://www.iana.org/assignments/message-headers/message-headers.xhtml
     """
 
-    def __init__(self, message=None):
+    def __init__(self, message=None, log_received_parse_errors=True):
         """
         Init a new object from a message object structure.
         """
         self._message = message
+        self._log_received_parse_errors = log_received_parse_errors
         log.debug(
             "All headers of emails: {}".format(", ".join(message.keys())))
         self.parse()
@@ -144,13 +150,14 @@ class MailParser(object):
             return six.text_type()
 
     @classmethod
-    def from_file_obj(cls, fp):
+    def from_file_obj(cls, fp, log_received_parse_errors=True):
         """
         Init a new object from a file-like object.
         Not for Outlook msg.
 
         Args:
             fp (file-like object): file-like object of raw email
+            log_received_parse_errors (bool): if True then only log error
 
         Returns:
             Instance of MailParser
@@ -165,16 +172,17 @@ class MailParser(object):
         finally:
             s = fp.read()
 
-        return cls.from_string(s)
+        return cls.from_string(s, log_received_parse_errors=log_received_parse_errors)
 
     @classmethod
-    def from_file(cls, fp, is_outlook=False):
+    def from_file(cls, fp, is_outlook=False, log_received_parse_errors=True):
         """
         Init a new object from a file path.
 
         Args:
             fp (string): file path of raw email
             is_outlook (boolean): if True is an Outlook email
+            log_received_parse_errors (bool): if True then only log error
 
         Returns:
             Instance of MailParser
@@ -188,31 +196,33 @@ class MailParser(object):
             log.debug("Removing temp converted Outlook email {!r}".format(fp))
             os.remove(fp)
 
-        return cls(message)
+        return cls(message, log_received_parse_errors=log_received_parse_errors)
 
     @classmethod
-    def from_file_msg(cls, fp):
+    def from_file_msg(cls, fp, log_received_parse_errors=True):
         """
         Init a new object from a Outlook message file,
         mime type: application/vnd.ms-outlook
 
         Args:
             fp (string): file path of raw Outlook email
+            log_received_parse_errors (bool): if True then only log error
 
         Returns:
             Instance of MailParser
         """
         log.debug("Parsing email from file Outlook")
         f, _ = msgconvert(fp)
-        return cls.from_file(f, True)
+        return cls.from_file(f, True, log_received_parse_errors=log_received_parse_errors)
 
     @classmethod
-    def from_string(cls, s):
+    def from_string(cls, s, log_received_parse_errors=True):
         """
         Init a new object from a string.
 
         Args:
             s (string): raw email
+            log_received_parse_errors (bool): if True then only log error
 
         Returns:
             Instance of MailParser
@@ -220,15 +230,16 @@ class MailParser(object):
 
         log.debug("Parsing email from string")
         message = email.message_from_string(s)
-        return cls(message)
+        return cls(message, log_received_parse_errors=log_received_parse_errors)
 
     @classmethod
-    def from_bytes(cls, bt):
+    def from_bytes(cls, bt, log_received_parse_errors=True):
         """
         Init a new object from bytes.
 
         Args:
             bt (bytes-like object): raw email as bytes-like object
+            log_received_parse_errors (bool): if True then only log error
 
         Returns:
             Instance of MailParser
@@ -238,7 +249,7 @@ class MailParser(object):
             raise MailParserEnvironmentError(
                 "Parsing from bytes is valid only for Python 3.x version")
         message = email.message_from_bytes(bt)
-        return cls(message)
+        return cls(message, log_received_parse_errors=log_received_parse_errors)
 
     def _reset(self):
         """
@@ -565,7 +576,7 @@ class MailParser(object):
         Return a list of all received headers parsed
         """
         output = self.received_raw
-        return receiveds_parsing(output)
+        return receiveds_parsing(output, _log_received_parse_errors=self._log_received_parse_errors)
 
     @property
     def received_json(self):

--- a/mailparser/utils.py
+++ b/mailparser/utils.py
@@ -243,7 +243,7 @@ def msgconvert(email):
         os.close(temph)
 
 
-def parse_received(received):
+def parse_received(received, _log_received_parse_errors=True):
     """
     Parse a single received header.
     Return a dictionary of values by clause.
@@ -273,7 +273,10 @@ def parse_received(received):
             # so either there's more than one or the current regex is wrong
             msg = "More than one match found for %s in %s" % (
                 pattern.pattern, received)
-            log.error(msg)
+
+            if _log_received_parse_errors:
+                log.error(msg)
+
             raise MailParserReceivedParsingError(msg)
         else:
             # otherwise we have one matching clause!
@@ -311,7 +314,7 @@ def parse_received(received):
     return values_by_clause
 
 
-def receiveds_parsing(receiveds):
+def receiveds_parsing(receiveds, _log_received_parse_errors=True):
     """
     This function parses the receiveds headers.
 
@@ -332,7 +335,7 @@ def receiveds_parsing(receiveds):
         log.debug("Try to parse {!r}".format(received))
         try:
             # try to parse the current received header...
-            values_by_clause = parse_received(received)
+            values_by_clause = parse_received(received, _log_received_parse_errors=_log_received_parse_errors)
         except MailParserReceivedParsingError:
             # if we can't, let's append the raw
             parsed.append({'raw': received})


### PR DESCRIPTION
There is logging of error when received header parsing returns more than 1 match and its most of the time not correct regex and end up in error. Added a flag in functions to suppress that logging. By default it will be true and will keep working as it is but it will give an option to users if they want to turn it off as it happened in our case, we dont want to parse it but its creating unnecessary noise in our error logging.