### PR TITLE
being more explicit with msgconvert tool error message

### DIFF
--- a/mailparser/utils.py
+++ b/mailparser/utils.py
@@ -231,8 +231,7 @@ def msgconvert(email):
                 stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
 
     except OSError as e:
-        print(e)
-        message = "Check if 'msgconvert' tool is installed"
+        message = "Check if 'msgconvert' tool is installed / %s" % e
         log.exception(message)
         raise MailParserOSError(message)
 

--- a/mailparser/utils.py
+++ b/mailparser/utils.py
@@ -230,8 +230,11 @@ def msgconvert(email):
                 command, stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
 
-    except Exception as e:
+    except OSError as e:
         print(e)
+        message = "Check if 'msgconvert' tool is installed"
+        log.exception(message)
+        raise MailParserOSError(message)
 
     else:
         stdoutdata, _ = out.communicate()

--- a/mailparser/utils.py
+++ b/mailparser/utils.py
@@ -219,21 +219,15 @@ def msgconvert(email):
     temph, temp = tempfile.mkstemp(prefix="outlook_")
     command = ["msgconvert", "--outfile", temp, email]
 
-    try:
-        if six.PY2:
-            with open(os.devnull, "w") as devnull:
-                out = subprocess.Popen(
-                    command, stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE, stderr=devnull)
-        elif six.PY3:
+    if six.PY2:
+        with open(os.devnull, "w") as devnull:
             out = subprocess.Popen(
                 command, stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-
-    except OSError:
-        message = "To use this function you must install 'msgconvert' tool"
-        log.exception(message)
-        raise MailParserOSError(message)
+                stdout=subprocess.PIPE, stderr=devnull)
+    elif six.PY3:
+        out = subprocess.Popen(
+            command, stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
 
     else:
         stdoutdata, _ = out.communicate()

--- a/mailparser/utils.py
+++ b/mailparser/utils.py
@@ -230,8 +230,8 @@ def msgconvert(email):
                 command, stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
 
-    except OSError:
-        raise ValueError
+    except Exception as e:
+        print(e)
 
     else:
         stdoutdata, _ = out.communicate()

--- a/mailparser/utils.py
+++ b/mailparser/utils.py
@@ -231,7 +231,7 @@ def msgconvert(email):
                 stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
 
     except OSError as e:
-        message = "Check if 'msgconvert' tool is installed / %s" % e
+        message = "Check if 'msgconvert' tool is installed / {!r}".format(e)
         log.exception(message)
         raise MailParserOSError(message)
 

--- a/mailparser/utils.py
+++ b/mailparser/utils.py
@@ -219,15 +219,19 @@ def msgconvert(email):
     temph, temp = tempfile.mkstemp(prefix="outlook_")
     command = ["msgconvert", "--outfile", temp, email]
 
-    if six.PY2:
-        with open(os.devnull, "w") as devnull:
+    try:
+        if six.PY2:
+            with open(os.devnull, "w") as devnull:
+                out = subprocess.Popen(
+                    command, stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE, stderr=devnull)
+        elif six.PY3:
             out = subprocess.Popen(
                 command, stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE, stderr=devnull)
-    elif six.PY3:
-        out = subprocess.Popen(
-            command, stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+
+    except OSError:
+        raise ValueError
 
     else:
         stdoutdata, _ = out.communicate()


### PR DESCRIPTION
While working on my own project, I noticed that the original OSError only told the user to install the msgconvert tool, but sometimes that's not the issue. In my case, I was having trouble with directories and files not being found, but the tests weren't showing me that. I think it would be much better if we could have both messages come up, one telling the user to check if the tool is indeed installed and another one being more specific about the problem they might be facing since it could be something totally different to that (like a permissions error).