### PR TITLE
#105 Fix header decoding for mailaddresses containing rfc2047 encoded commas

### DIFF
--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -544,9 +544,12 @@ class MailParser(object):
 
         # object headers
         elif name_header in ADDRESSES_HEADERS:
-            h = decode_header_part(self.message.get(
-                name_header, six.text_type()))
-            return email.utils.getaddresses([h])
+            h = self.message.get(name_header, six.text_type())
+            address_list = email.utils.getaddresses([h])
+            return [
+                (decode_header_part(address[0]), decode_header_part(address[1]))
+                for address in address_list
+            ]
 
         # others headers
         else:

--- a/tests/mails/mail_test_16
+++ b/tests/mails/mail_test_16
@@ -1,0 +1,7 @@
+Delivered-To: bruce@untroubled.org
+Received: (fqmail 26559 invoked from network); 21 Aug 2016 10:49:40 -0000
+Reply-To: =?ISO-8859-1?Q?Moore=2C_Keith?= <moore@cs.utk.edu>
+From: =?ISO-8859-1?Q?Moore=2C_Keith?= <moore@cs.utk.edu>
+Subject: PI
+Date: Fri, 19 Aug 2016 15:33:29 +0100
+MIME-Version: 1.0

--- a/tests/test_mail_parser.py
+++ b/tests/test_mail_parser.py
@@ -65,6 +65,7 @@ mail_test_12 = os.path.join(base_path, 'mails', 'mail_test_12')
 mail_test_13 = os.path.join(base_path, 'mails', 'mail_test_13')
 mail_test_14 = os.path.join(base_path, 'mails', 'mail_test_14')
 mail_test_15 = os.path.join(base_path, 'mails', 'mail_test_15')
+mail_test_16 = os.path.join(base_path, 'mails', 'mail_test_16')
 mail_malformed_1 = os.path.join(base_path, 'mails', 'mail_malformed_1')
 mail_malformed_2 = os.path.join(base_path, 'mails', 'mail_malformed_2')
 mail_malformed_3 = os.path.join(base_path, 'mails', 'mail_malformed_3')
@@ -105,6 +106,10 @@ class TestMailParser(unittest.TestCase):
         for i in attachments:
             self.assertTrue(os.path.exists(os.path.join(random_path, i)))
         shutil.rmtree(random_path)
+
+    def test_header_rfc2047_decoding(self):
+        mail = mailparser.parse_from_file(mail_test_16)
+        self.assertEqual(mail._from, [('Moore, Keith', 'moore@cs.utk.edu')])
 
     def test_issue62(self):
         mail = mailparser.parse_from_file(mail_test_14)


### PR DESCRIPTION
That's a proposal to fix #105
