### PR TITLE
Fix for regex parsing misbehaviour when mail id in received headers ends with "-by" 

### DIFF
--- a/mailparser/const.py
+++ b/mailparser/const.py
@@ -42,7 +42,7 @@ RECEIVED_PATTERNS = [
     # envelope-from and -sender seem to optionally have space and/or
     # ( before them other clauses must have whitespace before
     (
-        r'(?:by\s+(?P<by>.+?)(?:\s*[(]?envelope-from|\s*'
+        r'(?:[^-]by\s+(?P<by>.+?)(?:\s*[(]?envelope-from|\s*'
         r'[(]?envelope-sender|\s+from|\s+with'
         r'(?! cipher)|\s+id|\s+for|\s+via|;))'
     ),


### PR DESCRIPTION
This should fix problems such as:

`More than one match found for (?:by\s+(?P<by>.+?)(?:\s*[(]?envelope-from|\s*[(]?envelope-sender|\s+from|\s+with(?! cipher)|\s+id|\s+for|\s+via|;)) in from 123.123.123.123 port=48602 helo=example.com by example.com with esmtps TLS1.2 tls TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 Exim 4.90-.1 envelope-from <example@example.com> id 1nqqB6-000B8x-By for example@example.com; Tue, 17 May 2022 05:55:28 +0000`

Example headers causing this issue:

https://gist.github.com/matevn/56914754904828c9cc1061af12320c81