### PR TITLE
Support for .id and .by top level domains in `parse_received`

### DIFF
--- a/src/mailparser/const.py
+++ b/src/mailparser/const.py
@@ -19,7 +19,6 @@ limitations under the License.
 
 import re
 
-
 REGXIP = re.compile(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}")
 
 JUNK_PATTERN = r"[ \(\)\[\]\t\n]+"
@@ -39,7 +38,7 @@ RECEIVED_PATTERNS = [
     # envelope-from and -sender seem to optionally have space and/or
     # ( before them other clauses must have whitespace before
     (
-        r"(?:[^-]by\s+(?P<by>.+?)(?:\s*[(]?envelope-from|\s*"
+        r"(?:[^-\.]by\s+(?P<by>.+?)(?:\s*[(]?envelope-from|\s*"
         r"[(]?envelope-sender|\s+from|\s+with"
         r"(?! cipher)|\s+id|\s+for|\s+via|;))"
     ),
@@ -48,7 +47,7 @@ RECEIVED_PATTERNS = [
         r"envelope-sender|\s+from|\s+by|\s+id|\s+for|\s+via|;))"
     ),
     (
-        r"[^\w](?:id\s+(?P<id>.+?)(?:\s*[(]?envelope-from|\s*"
+        r"[^\w\.](?:id\s+(?P<id>.+?)(?:\s*[(]?envelope-from|\s*"
         r"[(]?envelope-sender|\s+from|\s+by|\s+with"
         r"(?! cipher)|\s+for|\s+via|;))"
     ),

--- a/tests/test_mail_parser.py
+++ b/tests/test_mail_parser.py
@@ -549,6 +549,48 @@ class TestMailParser(unittest.TestCase):
         s = ported_string(raw_data)
         self.assertEqual(s, "test")
 
+    def test_parse_domain_with_tld_dot_id(self):
+        """Support for .id tld (Indonesia)"""
+        received = """
+            from web.myhost.id
+            by smtp.domain.id (Proxmox) with ESMTPS id SOMEIDHERE
+            for <email@example.id>; Wed, 19 Feb 2025 15:00:00 +0700 (WIB)
+        """.strip()
+
+        expected = {
+            "from": "web.myhost.id",
+            "by": "smtp.domain.id (Proxmox)",
+            "with": "ESMTPS",
+            "id": "SOMEIDHERE",
+            "for": "<email@example.id>",
+            "date": "Wed, 19 Feb 2025 15:00:00 +0700 (WIB)",
+        }
+
+        values_by_clause = parse_received(received)
+
+        self.assertEqual(expected, values_by_clause)
+
+    def test_parse_domain_with_tld_dot_by(self):
+        """Support for .by tld (Belarus)"""
+        received = """
+            from web.myhost.by
+            by smtp.domain.by (Proxmox) with ESMTPS id SOMEIDHERE
+            for <email@example.by>; Wed, 19 Feb 2025 15:00:00 +0700 (WIB)
+        """.strip()
+
+        expected = {
+            "from": "web.myhost.by",
+            "by": "smtp.domain.by (Proxmox)",
+            "with": "ESMTPS",
+            "id": "SOMEIDHERE",
+            "for": "<email@example.by>",
+            "date": "Wed, 19 Feb 2025 15:00:00 +0700 (WIB)",
+        }
+
+        values_by_clause = parse_received(received)
+
+        self.assertEqual(expected, values_by_clause)
+
     def test_standard_outlook(self):
         """Verify a basic outlook received header works."""
         received = """


### PR DESCRIPTION
# Context

Linked to https://github.com/SpamScope/mail-parser/issues/129

# Content

- Improve regex to not look for id/by with a leading `.` (dot)
- Add unit tests