### PR TITLE
Account for missing and invalid address headers

### DIFF
--- a/src/mailparser/const.py
+++ b/src/mailparser/const.py
@@ -78,7 +78,8 @@ RECEIVED_COMPILED_LIST = [re.compile(i, re.I | re.DOTALL) for i in RECEIVED_PATT
 
 EPILOGUE_DEFECTS = {"StartBoundaryNotFoundDefect"}
 
-ADDRESSES_HEADERS = set(["bcc", "cc", "delivered-to", "from", "reply-to", "to"])
+ADDRESS_HEADERS = set(["delivered-to", "from", "sender"])
+ADDRESSES_HEADERS = set(["bcc", "cc", "reply-to", "to"])
 
 # These parts are always returned
 OTHERS_PARTS = set(

--- a/src/mailparser/core.py
+++ b/src/mailparser/core.py
@@ -601,7 +601,7 @@ class MailParser(object):
                                       parsed_address[-1].strip(">"))
                     return parsed_address
 
-        elif name_header in ADDRESSES_HEADERS:
+        if name_header in ADDRESSES_HEADERS:
             h = decode_header_part(self.message.get(name_header, six.text_type()))
             if h == "":
                 return []

--- a/src/mailparser/core.py
+++ b/src/mailparser/core.py
@@ -597,7 +597,7 @@ class MailParser(object):
                         self._defects.append(defect)
                         self._has_defects = True
                     parsed_address = h.split("<")
-                    parsed_address = (parsed_address[0].strip(),
+                    parsed_address = (parsed_address[0].strip().strip('"'),
                                       parsed_address[-1].strip(">"))
                 return parsed_address
 

--- a/src/mailparser/core.py
+++ b/src/mailparser/core.py
@@ -599,9 +599,9 @@ class MailParser(object):
                     parsed_address = h.split("<")
                     parsed_address = (parsed_address[0].strip(),
                                       parsed_address[-1].strip(">"))
-                    return parsed_address
+                return parsed_address
 
-        if name_header in ADDRESSES_HEADERS:
+        elif name_header in ADDRESSES_HEADERS:
             h = decode_header_part(self.message.get(name_header, six.text_type()))
             if h == "":
                 return []

--- a/src/mailparser/utils.py
+++ b/src/mailparser/utils.py
@@ -42,6 +42,7 @@ import tempfile
 import six
 
 from mailparser.const import (
+    ADDRESS_HEADERS,
     ADDRESSES_HEADERS,
     JUNK_PATTERN,
     OTHERS_PARTS,
@@ -519,10 +520,11 @@ def get_mail_keys(message, complete=True):
     if complete:
         log.debug("Get all headers")
         all_headers_keys = {i.lower() for i in message.keys()}
-        all_parts = ADDRESSES_HEADERS | OTHERS_PARTS | all_headers_keys
+        all_parts = ADDRESS_HEADERS | ADDRESSES_HEADERS | OTHERS_PARTS | \
+            all_headers_keys
     else:
         log.debug("Get only mains headers")
-        all_parts = ADDRESSES_HEADERS | OTHERS_PARTS
+        all_parts = ADDRESS_HEADERS | ADDRESSES_HEADERS | OTHERS_PARTS
 
     log.debug("All parts to get: {}".format(", ".join(all_parts)))
     return all_parts


### PR DESCRIPTION
Python began strict email address format verification [by default](https://github.com/python/cpython/commit/4a153a1d3b18803a684cd1bcc2cdf3ede3dbae19) in Python 3.13 and backported the changes for [security reasons](https://github.com/advisories/GHSA-5mwm-wccq-xqcp).

As a result, when an address header is not used or malformed, `mail-parser` will return `[('','')]` (issues #132 and #133)

To fix these issues while maintaining the security of the default `strict=True` option in `email.utils.parseaddr` and `email.utils.getaddresses`, the following changes were made to `mail-parser`:

- The existing constant `ADDRESSES_HEADERS` list now only includes headers that can contain multiple addresses
  - `bcc`
  - `cc`
  - `reply-to`
  - `to`
- A new constant `ADDRESS_HEADERS` list includes headers that can only contain one address
  - `delivered-to`
  - `from`
  - `sender`
- Header parsing is only attempted if the header exists and has a value (Closes #133)
- Headers in the `ADDRESS_HEADERS` list are parsed using `email.utils.parseaddr` instead of `email.utils.getaddresses`, returning a tuple instead of a list of tuples
- For headers in either list, if  an invalid address header is detected, a string stating `Invalid {} header` is added to the `defects` list, where `{}` is the name of the header, and `has_defects` is set to `True`
- Invalid headers in the `ADDRESS_HEADERS` are parsed manually if `email.utils.parseaddr` considers the address invalid, in order to show the intent of the defect on mail clients (Closes #132)

## Demo email 1

```enail
From: alice@example.com <bob@example.com>
To: example@example.com
Subject: Example Email

Hello world!
```

## Demo 1 JSON output before the changes

```json
{
  "from": [
    [
      "",
      ""
    ]
  ],
  "delivered-to": [
    [
      "",
      ""
    ]
  ],
  "cc": [
    [
      "",
      ""
    ]
  ],
  "body": "Hello world!",
  "to_domains": [
    "",
    "example.com"
  ],
  "reply-to": [
    [
      "",
      ""
    ]
  ],
  "subject": "Example Email",
  "bcc": [
    [
      "",
      ""
    ]
  ],
  "to": [
    [
      "",
      "example@example.com"
    ]
  ],
  "has_defects": false
}
```

## Demo 1 JSON output after the changes

```json
{
  "to": [
    [
      "",
      "example@example.com"
    ]
  ],
  "body": "Hello world!",
  "from": [
    "alice@example.com",
    "bob@example.com"
  ],
  "subject": "Example Email",
  "to_domains": [
    "example.com"
  ],
  "has_defects": true,
  "defects": [
    "Invalid from header"
  ],
  "defects_categories": []
}
```

## Demo email 2

```enail
From: alice@example.com
To: bob@example.com
Subject: Example Email

Hello world!
```

## Demo 2 JSON output before the changes

```json
{
  "from": [
    [
      "",
      ""
    ]
  ],
  "delivered-to": [
    [
      "",
      ""
    ]
  ],
  "cc": [
    [
      "",
      ""
    ]
  ],
  "body": "Hello world!",
  "to_domains": [
    "",
    "example.com"
  ],
  "reply-to": [
    [
      "",
      ""
    ]
  ],
  "subject": "Example Email",
  "bcc": [
    [
      "",
      ""
    ]
  ],
  "to": [
    [
      "",
      "bob@example.com"
    ]
  ],
  "has_defects": false
}
```

## Demo 2 JSON output after the changes

```json
{
  "to": [
    [
      "",
      "bob@example.com"
    ]
  ],
  "body": "Hello world!",
  "from": [
    "",
    "alice@example.com"
  ],
  "subject": "Example Email",
  "to_domains": [
    "example.com"
  ],
  "has_defects": false,
  "defects": [],
  "defects_categories": []
}
```