### PR TITLE
Remove ipaddress library install and bump version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ package_dir =
 	=src
 packages = find:
 install_requires =
-	ipaddress
 	six
 python_requires = >=3.7
 

--- a/src/mailparser/version.py
+++ b/src/mailparser/version.py
@@ -17,4 +17,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "4.1.2"
+__version__ = "4.1.3"


### PR DESCRIPTION
* `ipaddress` is part of the standard Python library since Python 3.3.
* It was introduced in https://github.com/SpamScope/mail-parser/pull/121/files#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52
* Per https://github.com/SpamScope/mail-parser/blob/develop/setup.cfg#L15, the minimum version of supported Python is 3.7
* Additionally, there is a vulnerability in the library - https://nvd.nist.gov/vuln/detail/CVE-2021-29921
* `mail-parser` version bumped from `4.1.2` to `4.1.3`