### PR TITLE
Fix TypeError from unconditional strict= kwarg on old Python patch releases

### DIFF
--- a/src/mailparser/utils.py
+++ b/src/mailparser/utils.py
@@ -134,7 +134,18 @@ def get_addresses(
     elif not isinstance(raw_header, str):
         raw_header = str(raw_header)
 
-    parsed = email.utils.getaddresses([raw_header], strict=True)
+    # ``strict`` was only added to ``getaddresses()`` as part of the
+    # CVE-2023-27043 hardening, and was backported to patch releases
+    # >=3.10.15, >=3.11.10, >=3.12.6 rather than to every 3.10-3.12
+    # release. On an older patch release within one of those minor
+    # versions, passing ``strict=True`` raises ``TypeError: getaddresses()
+    # got an unexpected keyword argument 'strict'``.
+    # ``email.utils.supports_strict_parsing`` is the stdlib's own
+    # capability flag for this, so use it instead of a version check.
+    if getattr(email.utils, "supports_strict_parsing", False):
+        parsed = email.utils.getaddresses([raw_header], strict=True)
+    else:
+        parsed = email.utils.getaddresses([raw_header])
 
     # If every result from the strict parser has an empty address — while the
     # raw header is non-empty — fall back to regex extraction so that the

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -647,6 +647,51 @@ class TestUtilsEdgeCases(unittest.TestCase):
         result = get_addresses("Plain Name <plain@example.com>")
         self.assertEqual(result, [("Plain Name", "plain@example.com")])
 
+    def test_get_addresses_omits_strict_kwarg_when_unsupported(self):
+        """
+        Regression for TypeError on Python patch releases that predate
+        the CVE-2023-27043 backport (< 3.10.15, < 3.11.10, < 3.12.6):
+        ``email.utils.getaddresses()`` doesn't accept ``strict=`` there,
+        and previously get_addresses() passed it unconditionally, raising
+
+            TypeError: getaddresses() got an unexpected keyword
+            argument 'strict'
+
+        on every affected interpreter. get_addresses() should now check
+        ``email.utils.supports_strict_parsing`` and omit ``strict=``
+        when it's not set, instead of assuming every supported Python
+        version has it.
+        """
+        with patch("mailparser.utils.email.utils.supports_strict_parsing", False):
+            with patch(
+                "mailparser.utils.email.utils.getaddresses",
+                return_value=[("Plain Name", "plain@example.com")],
+            ) as mock_getaddresses:
+                result = get_addresses("Plain Name <plain@example.com>")
+
+        mock_getaddresses.assert_called_once_with(["Plain Name <plain@example.com>"])
+        self.assertEqual(result, [("Plain Name", "plain@example.com")])
+
+    def test_get_addresses_uses_strict_kwarg_when_supported(self):
+        """
+        On interpreters that do support it (the common case in CI and
+        in production), get_addresses() should still pass
+        ``strict=True`` as before, so the CVE-2023-27043 hardening and
+        the existing regex fallback for non-compliant display names
+        keep working unchanged.
+        """
+        with patch("mailparser.utils.email.utils.supports_strict_parsing", True):
+            with patch(
+                "mailparser.utils.email.utils.getaddresses",
+                return_value=[("Plain Name", "plain@example.com")],
+            ) as mock_getaddresses:
+                result = get_addresses("Plain Name <plain@example.com>")
+
+        mock_getaddresses.assert_called_once_with(
+            ["Plain Name <plain@example.com>"], strict=True
+        )
+        self.assertEqual(result, [("Plain Name", "plain@example.com")])
+
     def test_mailparser_from_bytes_preserves_unicode_display_name(self):
         """
         Regression: Header objects from Message.get(name) must round-trip


### PR DESCRIPTION
## Summary

`get_addresses()` unconditionally passes `strict=True` to `email.utils.getaddresses()`. That keyword only exists as part of the CVE-2023-27043 hardening, and CPython backported it to patch releases `>=3.10.15`, `>=3.11.10`, `>=3.12.6` — not to every release within those minor versions. On an older patch release (e.g. 3.11.3), calling `get_addresses()` for any address header raises:

```
TypeError: getaddresses() got an unexpected keyword argument 'strict'
```

which breaks address parsing entirely on that interpreter (and, transitively, any project depending on mail-parser to parse address headers on such a host).

Reported via a downstream consumer (parsedmarc): https://github.com/domainaware/parsedmarc/issues/808

## Fix

`email.utils.supports_strict_parsing` is the stdlib's own capability flag for this hardening (present and `True` on the patched releases above). `get_addresses()` now checks it and only passes `strict=True` when the running interpreter actually supports it, falling back to the pre-hardening call signature (`getaddresses([raw_header])`) otherwise. Everything else — the existing regex fallback for RFC-non-compliant display names, `Header` handling, etc. — is unaffected on interpreters that do support strict parsing, which is the common case in CI and production.

## Test plan

- [x] Added `test_get_addresses_omits_strict_kwarg_when_unsupported` and `test_get_addresses_uses_strict_kwarg_when_supported` to `tests/test_utils.py`, both mocking `email.utils.getaddresses`/`email.utils.supports_strict_parsing` to assert the exact call signature used in each case.
- [x] `uv run pytest tests/` — 212 passed (full suite, including the `outlook` extra).
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean.
- [x] `pre-commit run --all-files` on the touched files — all hooks pass, including the `pyright` hook.
