### PR TITLE
Fix broken string literal that disabled the quoted-printable attachment branch

### DIFF
--- a/src/mailparser/core.py
+++ b/src/mailparser/core.py
@@ -407,9 +407,7 @@ class MailParser:
                         binary = False
                         log.debug(f"Filename {filename!r} part {i!r} is multipart")
                     elif transfer_encoding == "base64" or (
-                        transfer_encoding
-                        == "quoted-\
-                       printable"
+                        transfer_encoding == "quoted-printable"
                         and "application" in mail_content_type
                     ):
                         payload = p.get_payload(decode=False)

--- a/tests/test_mail_parser.py
+++ b/tests/test_mail_parser.py
@@ -399,6 +399,31 @@ class TestMailParser(unittest.TestCase):
         result = len(mail.attachments)
         self.assertEqual(1, result)
 
+    def test_quoted_printable_application_attachment(self):
+        # A quoted-printable application/* attachment must be kept as binary
+        # (raw QP text), not decoded as UTF-8, which drops the non-UTF8 bytes.
+        import quopri
+
+        original = b"\xff\xfe\x00\x01PDFdata\x80\x81\x82\xc0\xc1"
+        qp = quopri.encodestring(original).decode("ascii")
+        raw = (
+            "From: a@b.com\r\nTo: c@d.com\r\nSubject: t\r\n"
+            "MIME-Version: 1.0\r\n"
+            'Content-Type: multipart/mixed; boundary="B"\r\n\r\n'
+            "--B\r\nContent-Type: text/plain\r\n\r\nbody\r\n"
+            '--B\r\nContent-Type: application/octet-stream; name="f.bin"\r\n'
+            "Content-Transfer-Encoding: quoted-printable\r\n"
+            'Content-Disposition: attachment; filename="f.bin"\r\n\r\n'
+            + qp
+            + "\r\n--B--\r\n"
+        )
+        attachment = mailparser.parse_from_string(raw).attachments[0]
+        self.assertTrue(attachment["binary"])
+        self.assertEqual(attachment["content_transfer_encoding"], "quoted-printable")
+        self.assertEqual(
+            quopri.decodestring(attachment["payload"].encode("ascii")), original
+        )
+
     def test_add_content_type(self):
         mail = mailparser.parse_from_file(mail_test_3)
 


### PR DESCRIPTION
In `core.py`'s `parse()`, the branch that keeps quoted-printable `application/*`
attachments as binary has a broken string literal:

```python
elif transfer_encoding == "base64" or (
    transfer_encoding
    == "quoted-\
                   printable"
    and "application" in mail_content_type
):
```

The backslash is a line continuation, so the continuation line's indentation
becomes part of the string — the comparison target is
`"quoted-                       printable"`, which never equals
`"quoted-printable"`. That branch is dead.

As a result a quoted-printable `application/*` attachment falls through to the
text branch and is decoded as UTF-8 with `errors="ignore"`, **silently dropping
every non-UTF8 byte** and setting `binary=False`. A 16-byte binary attachment
comes back as 9 bytes; the original file is unrecoverable.

Joining the literal to `== "quoted-printable"` restores the intended
binary-preserving path (the `base64` operand next to it is already a clean
single-line literal). Added a test with a quoted-printable
`application/octet-stream` attachment that now round-trips losslessly; the
existing `text/plain` quoted-printable test is unaffected (it stays
`binary=False`), which is why the bug was never caught.

---
This PR was authored by an AI coding agent (Claude Code) running on this account:
the AI found the bug, ran the repro, wrote the test, and wrote this description.
The human account holder reviews every change and is accountable for it. The
verification is real and re-runnable from the diff. If this isn't the kind of
contribution you want, say so and I'll close it.
